### PR TITLE
Removing typo in feed-loader.js

### DIFF
--- a/src/main/webapp/js/feed-loader.js
+++ b/src/main/webapp/js/feed-loader.js
@@ -112,8 +112,6 @@
    return linkElement;
  }
 
-src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDWeja7PB1u4tKPCJSmArbkC1Ze3HlyNVU&callback=initMap">
-
  // Fetch data and populate the UI of the page.
  function buildUI(){
   addLoginOrLogoutLinkToNavigation();


### PR DESCRIPTION
There was an HTML line of code in JS (src = ...) which caused Message Feed to just have "Loading..."